### PR TITLE
Fix 'big files freeze issue' and windows support

### DIFF
--- a/cmd/iso9660/main.go
+++ b/cmd/iso9660/main.go
@@ -67,7 +67,7 @@ Usage:
 		fmt.Printf("Extracting %s...\n", fp)
 
 		freader := f.Sys().(io.Reader)
-		ff, err := os.Create(fp)
+		ff, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		if err != nil {
 			panic(err)
 		}
@@ -76,10 +76,6 @@ Usage:
 				panic(err)
 			}
 		}()
-
-		if err := ff.Chmod(f.Mode()); err != nil {
-			panic(err)
-		}
 
 		if _, err := io.Copy(ff, freader); err != nil {
 			panic(err)

--- a/reader.go
+++ b/reader.go
@@ -23,7 +23,7 @@ var (
 // from its constructor.
 type Reader struct {
 	// File descriptor to the opened ISO image
-	image io.ReadSeeker
+	image *os.File
 	// Copy of unencoded Primary Volume Descriptor
 	pvd PrimaryVolume
 	// Queue used to walk through file system iteratively
@@ -35,7 +35,7 @@ type Reader struct {
 }
 
 // NewReader creates a new ISO 9660 image reader.
-func NewReader(rs io.ReadSeeker) (*Reader, error) {
+func NewReader(rs *os.File) (*Reader, error) {
 	// Starts reading from image data area
 	sector := dataAreaSector
 	// Iterates over volume descriptors until it finds the primary volume descriptor


### PR DESCRIPTION
I think changing io.ReadSeeker to os.File is not good idea,
but reading all file in memory (how to freeze win10) not better.

Solution: change all .Read code to .ReadAt (No more seeks)
