### PR TITLE
Update main.go to close files immediately after copy.

### DIFF
--- a/cmd/iso9660/main.go
+++ b/cmd/iso9660/main.go
@@ -72,13 +72,14 @@ Usage:
 			panic(err)
 		}
 		
-		if _, err := io.Copy(ff, freader); err != nil {
+		_, err = io.Copy(ff, freader)
+		
+		cerr := ff.Close() // With or without an error from Copy, we want to attempt Close.
+		
+		if err != nil { // Panic with Copy's err.
 			panic(err)
+		} else if cerr != nil {
+			panic(cerr)
 		}
-
-		if err := ff.Close(); err != nil {
-			panic(err)
-		}
-
 	}
 }

--- a/cmd/iso9660/main.go
+++ b/cmd/iso9660/main.go
@@ -71,14 +71,14 @@ Usage:
 		if err != nil {
 			panic(err)
 		}
-		defer func() {
-			if err := ff.Close(); err != nil {
-				panic(err)
-			}
-		}()
-
+		
 		if _, err := io.Copy(ff, freader); err != nil {
 			panic(err)
 		}
+
+		if err := ff.Close(); err != nil {
+			panic(err)
+		}
+
 	}
 }


### PR DESCRIPTION
Moved the ff.Close call outside of the defer and below the io.Copy call.  This will allow huge ISO images to be read on devices with limited resources.