### PR TITLE
remove c4milo/gotoolkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,4 @@ deps:
 	go get github.com/c4milo/github-release
 	go get github.com/mitchellh/gox
 	go get github.com/docopt/docopt-go
-	go get github.com/c4milo/gotoolkit
 	go get github.com/hooklift/assert


### PR DESCRIPTION
Hello,

this PR is more a question than a real patch,
why did you code your own implementation of slicequeue ? 
golang already implement it a long time ago with container/list