### PR TITLE
Use any ReadSeeker instead of os.File

### DIFF
--- a/iso9660.go
+++ b/iso9660.go
@@ -30,7 +30,7 @@ type File struct {
 	DirectoryRecord
 	fileID string
 	// We have the raw image here only to be able to access file extents
-	image *os.File
+	image *ImageReader
 }
 
 // Name returns the file's name.

--- a/iso9660.go
+++ b/iso9660.go
@@ -30,7 +30,7 @@ type File struct {
 	DirectoryRecord
 	fileID string
 	// We have the raw image here only to be able to access file extents
-	image *ImageReader
+	image *imageReader
 }
 
 // Name returns the file's name.

--- a/reader.go
+++ b/reader.go
@@ -19,11 +19,11 @@ var (
 	ErrCorruptedImage = func(err error) error { return fmt.Errorf("corrupted-image: %s", err) }
 )
 
-type ImageReader struct {
+type imageReader struct {
 	io.ReadSeeker
 }
 
-func (ir *ImageReader) ReadAt(p []byte, off int64) (n int, err error) {
+func (ir *imageReader) ReadAt(p []byte, off int64) (n int, err error) {
 	// 0 means io.SeekStart. Not using constant for backwards compatibility.
 	if _, err = ir.Seek(off, 0); err == nil {
 		n, err = ir.Read(p)
@@ -35,7 +35,7 @@ func (ir *ImageReader) ReadAt(p []byte, off int64) (n int, err error) {
 // from its constructor.
 type Reader struct {
 	// File descriptor to the opened ISO image
-	image *ImageReader
+	image *imageReader
 	// Copy of unencoded Primary Volume Descriptor
 	pvd PrimaryVolume
 	// Queue used to walk through file system iteratively
@@ -71,7 +71,7 @@ func NewReader(rs io.ReadSeeker) (*Reader, error) {
 			}
 
 			reader := new(Reader)
-			reader.image = &ImageReader{rs}
+			reader.image = &imageReader{rs}
 			reader.queue = new(gotoolkit.SliceQueue)
 
 			if err := reader.unpackPVD(); err != nil {


### PR DESCRIPTION
Changing the input interface to ReadSeeker will let us use a much wider range of input files (like files over network, etc).