### PR TITLE
 Follow ReadAt specification as much as we can 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -26,7 +26,7 @@ type imageReader struct {
 func (ir *imageReader) ReadAt(p []byte, off int64) (n int, err error) {
 	// 0 means io.SeekStart. Not using constant for backwards compatibility.
 	if _, err = ir.Seek(off, 0); err == nil {
-		n, err = ir.Read(p)
+		n, err = io.ReadFull(ir, p)
 	}
 	return
 }

--- a/reader.go
+++ b/reader.go
@@ -24,9 +24,26 @@ type imageReader struct {
 }
 
 func (ir *imageReader) ReadAt(p []byte, off int64) (n int, err error) {
-	// 0 means io.SeekStart. Not using constant for backwards compatibility.
+	// If the underlying ReadSeeker happen to implement ReadAt, let's use it.
+	if readerAt, ok := ir.ReadSeeker.(io.ReaderAt); ok {
+		return readerAt.ReadAt(p, off)
+	}
+	// If not we are going to emulate it with Seeking and Reading.
+	// ReadAt should not affect the Seeker's position,
+	// thus we need to get the current position first, and Seek back to it after we're done.
+	// 1 means io.SeekCurrent. Not using constant for backwards compatibility.
+	// 0 means io.SeekStart.
+	if curPos, err := ir.Seek(0, 1); err == nil {
+		// We can only Seek back later if we could get the current position
+		defer ir.Seek(curPos, 0)
+	}
 	if _, err = ir.Seek(off, 0); err == nil {
+		// ReadAt should fill the buffer if there are no errors in the stream, so let's use ReadFull.
 		n, err = io.ReadFull(ir, p)
+		if err == io.ErrUnexpectedEOF {
+			// ReadAt should return EOF instead of ErrUnexpectedEOF
+			err = io.EOF
+		}
 	}
 	return
 }


### PR DESCRIPTION
So, after looking into the docs regarding ReadAt, I've found that it should
- Fill the given buffer when possible
- Shouldn't affect the Seeker's position
- Should be thread-safe

I've made some modifications to comply with the first 2 points.
But I didn't feel like we should use mutexes to make it thread-safe, as it would have some performance impacts, and as far as I know the library does not use multiple go routines, so we should be fine.